### PR TITLE
Update Docker login action to use Environment Files

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,23 @@ This project is licensed under the MIT License. See the [LICENSE](LICENSE) file 
 
 2. The GitHub Actions workflow will automatically build and deploy the application when you push changes to the main branch.
 
+### Using Environment Files for DockerHub Login
+
+1. Ensure that you have set up the necessary secrets in your GitHub repository:
+   - `DOCKER_USERNAME`: Your DockerHub username
+   - `DOCKER_PASSWORD`: Your DockerHub password
+   - `AZURE_WEBAPP_PUBLISH_PROFILE`: Your Azure Web App publish profile
+
+2. Create a file named `DOCKERHUB_LOGIN.env` in the `.github/workflows` directory with the following content:
+   ```
+   DOCKER_USERNAME=<your-docker-username>
+   DOCKER_PASSWORD=<your-docker-password>
+   ```
+
+3. Update the GitHub Actions workflow to use the Environment Files for DockerHub login.
+
+4. The GitHub Actions workflow will automatically build and deploy the application when you push changes to the main branch.
+
 ## GitHub Codespaces Setup
 
 ### Setting up GitHub Codespaces


### PR DESCRIPTION
Update the README.md to reflect the use of Environment Files for DockerHub login.

* **README.md**
  - Add a new section "Using Environment Files for DockerHub Login" with instructions on setting up secrets and creating the `DOCKERHUB_LOGIN.env` file.
  - Update the deployment instructions to include the use of Environment Files for DockerHub login.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AbaSheger/Personal-Expense-Tracker/pull/10?shareId=fc345e52-8092-41b3-9c14-0cf55e0cccd8).