### PR TITLE
Add category enum to replace string

### DIFF
--- a/PersonalExpenseTracker/CategoryEnum.cs
+++ b/PersonalExpenseTracker/CategoryEnum.cs
@@ -1,0 +1,13 @@
+namespace PersonalExpenseTracker
+{
+    public enum CategoryEnum
+    {
+        Food,
+        Transportation,
+        Utilities,
+        Entertainment,
+        Healthcare,
+        Education,
+        Miscellaneous
+    }
+}

--- a/PersonalExpenseTracker/Expense.cs
+++ b/PersonalExpenseTracker/Expense.cs
@@ -3,7 +3,7 @@ namespace PersonalExpenseTracker
     public class Expense
     {
         public decimal Amount { get; set; }
-        public string Category { get; set; }
+        public CategoryEnum Category { get; set; }
         public DateTime Date { get; set; }
         public string Description { get; set; }
     }

--- a/PersonalExpenseTracker/ExpenseForm.cs
+++ b/PersonalExpenseTracker/ExpenseForm.cs
@@ -10,6 +10,7 @@ namespace PersonalExpenseTracker
         public ExpenseForm()
         {
             InitializeComponent();
+            PopulateCategoryComboBox();
         }
 
         public ExpenseForm(Expense expense) : this()
@@ -153,6 +154,15 @@ namespace PersonalExpenseTracker
 
         }
 
+        private void PopulateCategoryComboBox()
+        {
+            comboBoxCategory.Items.Clear();
+            foreach (var category in Enum.GetValues(typeof(CategoryEnum)))
+            {
+                comboBoxCategory.Items.Add(category);
+            }
+        }
+
         private void ButtonSave_Click(object sender, EventArgs e)
         {
             if (ValidateInput())
@@ -160,7 +170,7 @@ namespace PersonalExpenseTracker
                 Expense = new Expense
                 {
                     Amount = decimal.Parse(textBoxAmount.Text),
-                    Category = comboBoxCategory.SelectedItem.ToString(),
+                    Category = (CategoryEnum)comboBoxCategory.SelectedItem,
                     Date = dateTimePickerDate.Value,
                     Description = textBoxDescription.Text
                 };

--- a/PersonalExpenseTracker/ExpenseManager.cs
+++ b/PersonalExpenseTracker/ExpenseManager.cs
@@ -43,7 +43,7 @@ namespace PersonalExpenseTracker
             return expenses;
         }
 
-        public List<Expense> GetExpensesByCategory(string category)
+        public List<Expense> GetExpensesByCategory(CategoryEnum category)
         {
             return expenses.Where(e => e.Category == category).ToList();
         }
@@ -53,12 +53,12 @@ namespace PersonalExpenseTracker
             return expenses.Sum(e => e.Amount);
         }
 
-        public decimal GetTotalExpensesByCategory(string category)
+        public decimal GetTotalExpensesByCategory(CategoryEnum category)
         {
             return expenses.Where(e => e.Category == category).Sum(e => e.Amount);
         }
 
-        public Dictionary<string, decimal> GetExpenseSummaryByCategory()
+        public Dictionary<CategoryEnum, decimal> GetExpenseSummaryByCategory()
         {
             return expenses.GroupBy(e => e.Category)
                            .ToDictionary(g => g.Key, g => g.Sum(e => e.Amount));

--- a/PersonalExpenseTracker/ExpenseSummaryForm.cs
+++ b/PersonalExpenseTracker/ExpenseSummaryForm.cs
@@ -15,7 +15,7 @@ namespace PersonalExpenseTracker
             InitializeComponent();
             this.expenseManager = expenseManager;
             this.categoryManager = categoryManager;
-            LoadCategories();
+            PopulateCategoryComboBox();
         }
 
         private void InitializeComponent()
@@ -88,13 +88,13 @@ namespace PersonalExpenseTracker
 
         }
 
-        private void LoadCategories()
+        private void PopulateCategoryComboBox()
         {
             comboBoxCategory.Items.Clear();
             comboBoxCategory.Items.Add("All Categories");
-            foreach (var category in categoryManager.GetCategories())
+            foreach (var category in Enum.GetValues(typeof(CategoryEnum)))
             {
-                comboBoxCategory.Items.Add(category.Name);
+                comboBoxCategory.Items.Add(category);
             }
             comboBoxCategory.SelectedIndex = 0;
         }
@@ -110,7 +110,8 @@ namespace PersonalExpenseTracker
 
             if (selectedCategory != "All Categories")
             {
-                expenses = expenses.Where(expense => expense.Category == selectedCategory);
+                var selectedCategoryEnum = (CategoryEnum)Enum.Parse(typeof(CategoryEnum), selectedCategory);
+                expenses = expenses.Where(expense => expense.Category == selectedCategoryEnum);
             }
 
             var expenseSummary = expenses

--- a/PersonalExpenseTracker/MainForm.cs
+++ b/PersonalExpenseTracker/MainForm.cs
@@ -140,9 +140,9 @@ namespace PersonalExpenseTracker
             // Load categories if needed
             comboBoxCategory.Items.Clear();
             comboBoxCategory.Items.Add("All Categories");
-            foreach (var category in categoryManager.GetCategories())
+            foreach (var category in Enum.GetValues(typeof(CategoryEnum)))
             {
-                comboBoxCategory.Items.Add(category.Name);
+                comboBoxCategory.Items.Add(category);
             }
             comboBoxCategory.SelectedIndex = 0;
         }


### PR DESCRIPTION
Update the category property to use an enum instead of a string and populate the category dropdowns with enum values.

* **Add CategoryEnum.cs**
  - Create a new enum `CategoryEnum` with values for each category.

* **Modify Expense.cs**
  - Update the `Category` property to use `CategoryEnum` instead of a string.

* **Modify ExpenseForm.cs**
  - Populate `comboBoxCategory` with values from `CategoryEnum` in the constructor.
  - Update the `ButtonSave_Click` method to use `CategoryEnum` for the `Category` property.

* **Modify ExpenseManager.cs**
  - Update methods to handle `CategoryEnum` instead of string for category-related methods.

* **Modify ExpenseSummaryForm.cs**
  - Populate `comboBoxCategory` with values from `CategoryEnum` in the constructor.
  - Update the `ButtonGenerateSummary_Click` method to use `CategoryEnum` for filtering expenses.

* **Modify MainForm.cs**
  - Update methods to use `CategoryEnum` for category selection and display.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AbaSheger/Personal-Expense-Tracker/pull/12?shareId=a417d82b-a98d-46e1-bef2-73808953f8a9).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a standardized expense category selection across the application, offering predefined options such as Food, Transportation, Utilities, Entertainment, Healthcare, Education, and Miscellaneous.
	- Enhanced user interfaces for expense entry and filtering to utilize these consistent category options.

- **Refactor**
	- Updated the underlying category handling for improved consistency and reliability in expense tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->