### PR TITLE
Fix build errors related to missing references

### DIFF
--- a/PersonalExpenseTracker/Expense.cs
+++ b/PersonalExpenseTracker/Expense.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace PersonalExpenseTracker
 {
     public class Expense


### PR DESCRIPTION
Add `using System;` directive to `PersonalExpenseTracker/Expense.cs` to resolve the `DateTime` type error.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/AbaSheger/Personal-Expense-Tracker/pull/14?shareId=5c30d87a-7009-4e13-9e9e-a5f170dbfb02).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Performed an internal update to enhance the usage of standard system capabilities. No changes have been made to public interfaces or end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->